### PR TITLE
:sparkles: Add append title feature

### DIFF
--- a/app/sonarr_youtubedl.py
+++ b/app/sonarr_youtubedl.py
@@ -322,8 +322,11 @@ class SonarrYTDL:
                     if ser["id"] == eps["seriesId"]:
                         cookies = None
                         url = ser["url"]
+
                         eps_title = (
                             f"{ser['title']} - {eps['title']}"
+                            if ser.get("preprend_with_title", False)
+                            else f"{eps['title']} {ser['title']}"
                             if ser.get("preprend_with_title", False)
                             else eps["title"]
                         )
@@ -380,17 +383,17 @@ class SonarrYTDL:
                                 "noplaylist": True,
                                 "writethumbnail": True,
                                 "check_formats": True,
-                                'forceipv4': True,
-                                'sleep_interval': 5,
-                                'max_sleep_interval': 30,
-                                'nocontinue': True,
-                                'nooverwrites': True,
-                                'throttled_rate': '100K',
-                                'concurrent_fragments': 5,
+                                "forceipv4": True,
+                                "sleep_interval": 5,
+                                "max_sleep_interval": 30,
+                                "nocontinue": True,
+                                "nooverwrites": True,
+                                "throttled_rate": "100K",
+                                "concurrent_fragments": 5,
                             }
 
                             ytdl_format_options = self.appendcookie(ytdl_format_options, cookies)
-                            
+
                             if "format" in ser:
                                 ytdl_format_options = self.customformat(ytdl_format_options, ser["format"])
 

--- a/app/sonarr_youtubedl.py
+++ b/app/sonarr_youtubedl.py
@@ -327,7 +327,7 @@ class SonarrYTDL:
                             f"{ser['title']} - {eps['title']}"
                             if ser.get("preprend_with_title", False)
                             else f"{eps['title']} {ser['title']}"
-                            if ser.get("preprend_with_title", False)
+                            if ser.get("append_with_title", False)
                             else eps["title"]
                         )
                         if "cookies_file" in ser:


### PR DESCRIPTION
In the case of a Series like "Pitch Meetings" where every episode ends with the words "Pitch Meeting" but that is not reflected in thetvdb, Use this "append_with_title" option to match the episodes.